### PR TITLE
Factor out the routine for calculating efforts and improve speed by reducing printouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    branches: [main]
+    # branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/src/carpalx.ts
+++ b/src/carpalx.ts
@@ -1,5 +1,13 @@
 import { Layout } from "./layout"
 
+import tnc5k from "../data/thai5k-freq.json"
+import { wisesight } from "../data/wisesight"
+import { wongnai } from "../data/wongnai"
+import { thaiTweets } from "../data/thai-tweets"
+import { sugreeTweets } from "../data/sugree-tweets"
+// import thaisumTestset from "../data/thaisum-testset.json"
+import thaisum from "../data/thaisum-full.json"
+
 // Default model params
 const kb = 0.3555,
   kp = 0.6423,
@@ -41,6 +49,25 @@ export default class Carpalx {
 
   constructor(options: CarpalxOptions = { layout: new Layout() }) {
     this.layout = options.layout
+  }
+
+  private datasets = [
+    {name: "TNC 5000", corpus: tnc5k},
+    {name: "Wisesight Sentiment", corpus: wisesight},
+    {name: "Wongnai Corpus", corpus: wongnai},
+    {name: "Thaisum", corpus: thaisum},
+    {name: "ThaiTweets", corpus: thaiTweets},
+    {name: "SugreeTweets", corpus: sugreeTweets},
+  ]
+
+  public sumTypingEfforts(noisy: boolean=false): number {
+    const efforts = this.datasets.map(dataset => this.typingEffort(dataset.corpus as Triads))
+    if (noisy) {
+      this.datasets.map((dataset, i) => {
+        console.log(`Typing Effort (${dataset.name} triads) :`, efforts[i])
+      })
+    }
+    return(efforts.reduce((a, b) => a + b, 0))
   }
 
   // 𝐸=1𝑁∑𝑖𝑛𝑖𝑒𝑖

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -1,6 +1,6 @@
 import fs from "fs"
 
-import Carpalx, { Triads } from "./carpalx"
+import Carpalx from "./carpalx"
 import { ILayout, Layout, LayoutOptions } from "./layout"
 
 const layoutName = (process.argv[2] as LayoutOptions["name"]) || "kedmanee"


### PR DESCRIPTION
Before, `typingEffort` calculation was in `carpalx`, but optimization requires calculating sum of typing efforts for different corpuses. Now the calculation is moved into `carpalx.ts`.

Also, logging in console take a considerable amount of time. Now the console logs only when there's an improvement or annealing so you can keep track of current score.

## Benchmarks

N = 100, 5 runs
Old average: 9.128s
New average: 8.534s (6.5% faster)

N = 1000, 2 runs
Old average: 82.535s
New average: 75.080s (9.0% faster)

-----
Note: I had to change display method because the refactoring moves logging into the `sumTypingEfforts` function. Once this function returns a value to the main loop, `console.clear()` got called, so it seems like nothing was printed. This end up saving some time ;)